### PR TITLE
W60x-I2C - fixed bug in machine_hard_i2c_transfer()

### DIFF
--- a/ports/w60x/machine/machine_i2c.c
+++ b/ports/w60x/machine/machine_i2c.c
@@ -158,8 +158,8 @@ int machine_hard_i2c_transfer(mp_obj_base_t *self_in, uint16_t addr, size_t n, m
     int wait;
     int transfer_ret = 0;
 
-    wait = 1000; // Experimental value, just guessed. 
-    while(tls_reg_read32((HR_I2C_CR_SR) & I2C_SR_BUSY) && wait > 0) { // Wait while the device is busy
+    wait = 1000; // Experimental value, just guessed.
+    while((tls_reg_read32(HR_I2C_CR_SR) & I2C_SR_BUSY) && wait > 0) { // Wait while the device is busy
         wait--;      // but not forever
     }
 


### PR DESCRIPTION
parenthesis-typo caused tls_reg_read() to hang on invalid register

Already created a PR for the Winnermicro fork as well