### PR TITLE
mimxrt/1170_evk: Reworked make-pins for ADC functions.

### DIFF
--- a/ports/mimxrt/pin.h
+++ b/ports/mimxrt/pin.h
@@ -66,6 +66,8 @@ enum {
     PIN_AF_MODE_ALT6,
     PIN_AF_MODE_ALT7,
     PIN_AF_MODE_ALT8,
+    PIN_AF_MODE_ALT9,
+    PIN_AF_MODE_ALT10
 };
 
 enum {


### PR DESCRIPTION
- Fixed make-pins to handle arbitrary number of AFs
- Added additional ADC regex to catch different ADC AF names of 11xx
- Modified ADC code generation to handle `ADC` or `LPADC` instances