### PR TITLE
Added math module to SAMD21 variant ICs

### DIFF
--- a/ports/samd/variants/samd21/mpconfigmcu.h
+++ b/ports/samd/variants/samd21/mpconfigmcu.h
@@ -9,7 +9,8 @@
 
 #define MICROPY_FLOAT_IMPL              (MICROPY_FLOAT_IMPL_FLOAT)
 #define MICROPY_PY_BUILTINS_COMPLEX     (0)
-#define MICROPY_PY_MATH                 (0)
+#define MICROPY_PY_MATH                 (1)
+#define MP_NEED_LOG2                    (1)
 #define MICROPY_PY_CMATH                (0)
 
 #define VFS_BLOCK_SIZE_BYTES            (1536) // 24x 64B flash pages;

--- a/ports/samd/variants/samd21/mpconfigmcu.mk
+++ b/ports/samd/variants/samd21/mpconfigmcu.mk
@@ -1,2 +1,31 @@
 
 SRC_S += shared/runtime/gchelper_m0.s
+
+SRC_MOD +=  $(addprefix lib/libm/,\
+	acoshf.c \
+	asinfacosf.c \
+	asinhf.c \
+	atan2f.c \
+	atanf.c \
+	atanhf.c \
+	ef_rem_pio2.c \
+	erf_lgamma.c \
+	fmodf.c \
+	kf_cos.c \
+	kf_rem_pio2.c \
+	kf_sin.c \
+	kf_tan.c \
+	log1pf.c \
+	math.c \
+	nearbyintf.c \
+	roundf.c \
+	sf_cos.c \
+	sf_erf.c \
+	sf_frexp.c \
+	sf_ldexp.c \
+	sf_modf.c \
+	sf_sin.c \
+	sf_tan.c \
+	wf_lgamma.c \
+	wf_tgamma.c \
+	)


### PR DESCRIPTION
The module `math` was only being included for SAMD51 MCUs, this patch adds SAMD21 support